### PR TITLE
Added Dockerfile to build frontend and containerize it. Hotfixed a bug for build errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.next
+node_modules
+.idea
+.git
+.env*
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+### Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+
+# Set environment variable
+ARG NODE_ENV=production
+
+# Copy package files
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Copy the source code, excluding some things unnecessary for the build, see .dockerignore
+COPY . .
+
+# Build the application
+ENV NODE_ENV=${NODE_ENV}
+RUN npm run build
+
+### Runtime stage
+FROM node:18-alpine AS runtime
+WORKDIR /app
+
+# Set environment variable
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+# Copy package files
+COPY --from=build /app/package.json ./
+COPY --from=build /app/package-lock.json ./
+
+RUN npm ci --only=production
+
+# Copy the built application
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/next.config.mjs ./
+COPY --from=build /app/messages ./messages
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,8 @@
+export const dynamic = 'force-dynamic'; 
+// TODO: Fix useTranslation not gracefully handling missing localizations.
+// It breaks npm run build, specifically the optimization for static pages
+// Even more specifically, Layout is a server component, because it's an async function,
+// but it needs to be rendered dynamically because of the client components it uses
 import '../styles/globals.css';
 
 import { ReactNode } from 'react';


### PR DESCRIPTION
development: Added Dockerfile to build frontend and containerize it.
- added Dockerfile. To run and be able to access it, you need to map port when running it, -p 3000:3000 for example

hotfix: Fixed npm run build
- made the layout.tsx(so basically the whole application) render dynamically. This seems to be caused by the useTranslation hook because it doesn't gracefully handle missing localization