### PR TITLE
Update reusable-docker-build.yml

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -39,8 +39,8 @@ jobs:
             LATEST_TAG=ghcr.io/${REPO_LOWER}:latest
           else
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-            IMAGE_TAG=ghcr.io/${REPO_LOWER}-dev:${{ inputs.branch }}-${VERSION}-${SHORT_SHA}
-            LATEST_TAG=ghcr.io/${REPO_LOWER}-dev:${{ inputs.branch }}-latest
+            IMAGE_TAG=ghcr.io/${REPO_LOWER}-${{ inputs.branch }}:${VERSION}-${SHORT_SHA}
+            LATEST_TAG=ghcr.io/${REPO_LOWER}-${{ inputs.branch }}:latest
           fi
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
moved the branch specification before the tag so instead of ghcr.io/ismd-validator-backend-dev:dev-latest or
ghcr.io/ismd-validator-backend-dev:test-latest

we'll have for example
ghcr.io/ismd-validator-backend-dev:latest
ghcr.io/ismd-validator-backend-test:latest