### PR TITLE
ci(security): add CodeQL + Trivy scans, align actions/checkout pin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+# GitHub-native SAST. Analyzes JavaScript/TypeScript source for vulnerabilities
+# (XSS, path traversal, unsafe deserialization, etc.). Free for public repos.
+# Findings appear in Security -> Code scanning.
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    - cron: '0 6 * * 1'   # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -20,7 +20,7 @@ jobs:
       should_build: ${{ steps.determine-version.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -75,7 +75,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Get full history
       

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -20,7 +20,7 @@ jobs:
       new_version: ${{ steps.new-version.outputs.version }}
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to get tags
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -44,7 +44,7 @@ jobs:
       ref: ${{ steps.determine_params.outputs.ref }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           # For workflow_run, check out the exact commit that built the image; otherwise use the current SHA
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
@@ -214,7 +214,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment
@@ -291,7 +291,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment
@@ -368,7 +368,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,65 @@
+name: Trivy Image Scan
+
+# Calls the reusable Trivy scanner owned by infrastructure repo.
+# Findings appear in this repo's Security -> Code scanning tab.
+#
+# Image taxonomy (see reusable-docker-build.yml):
+#   dev branch  -> ghcr.io/datagov-cz/ismd-validator-frontend-dev:latest    (deployed to dev env)
+#   main branch -> ghcr.io/datagov-cz/ismd-validator-frontend:latest        (deployed to test + prod)
+#
+# Triggers:
+#   * After "Build Docker on Dev"  completes -> scan dev image
+#   * After "Build Docker on Main" completes -> scan main image
+#   * Weekly Monday 07:00 UTC               -> scan BOTH (CVE-feed drift)
+#   * Manual dispatch                        -> pick dev/main/both
+
+on:
+  workflow_run:
+    workflows: ["Build Docker on Dev", "Build Docker on Main"]
+    types: [completed]
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      image_variant:
+        description: 'Which image(s) to scan'
+        required: true
+        type: choice
+        options: [dev, main, both]
+        default: both
+      soft_fail:
+        description: 'Non-blocking: workflow stays green even if findings exist (default). Uncheck to make scan blocking for this run.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  scan-dev:
+    name: Scan dev image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Dev' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'dev' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-validator-frontend-dev:latest
+      # Default non-blocking. Only a manual dispatch with soft_fail=false flips it.
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit
+
+  scan-main:
+    name: Scan main image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Main' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'main' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-validator-frontend:latest
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit


### PR DESCRIPTION
Security:
- CodeQL JS/TS scan: SAST on push/PR to dev+main, weekly cron,
  security-extended queries, non-blocking by default (require via
  branch protection if desired).
- Trivy image scan stub calling reusable in datagov-cz/ismd-infrastructure.
  Scans both -dev and prod-bound images after their respective Build
  Docker workflows complete, plus weekly drift cron and manual dispatch.
  Findings appear in Security -> Code scanning.

Workflow hygiene:
- actions/checkout pins aligned to @v6 (was @v6.0.2 across
  reusable-test, reusable-docker-build, release-version, push-to-main,
  and trigger-deployment).