### PR TITLE
feat(middleware): drive coming-soon bypass from SITE_PREVIEW_SECRET env

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ISMD - Připravujeme',
+  description:
+    'Validátor pro kontrolu a převod slovníků v rámci Informačního systému pro modelování dat se připravuje k veřejnému spuštění.',
+};
+
+export default function ComingSoonPage() {
+  return (
+    <main className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16">
+      <div className="max-w-2xl text-center">
+        <h1 className="text-4xl font-medium text-blue-primary mb-6">
+          Připravujeme
+        </h1>
+        <p className="text-lg text-gray-700 leading-relaxed mb-4">
+          Validátor pro kontrolu a převod slovníků v rámci Informačního systému
+          pro modelování dat dokončujeme. Veřejně dostupný bude v nejbližší
+          době.
+        </p>
+        <p className="text-base text-gray-500">Děkujeme za trpělivost.</p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ISMD - Probíhá údržba',
+  description: 'Aplikace je dočasně nedostupná z důvodu plánované údržby.',
+};
+
+export default function MaintenancePage() {
+  return (
+    <main className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16">
+      <div className="max-w-2xl text-center">
+        <h1 className="text-4xl font-medium text-blue-primary mb-6">
+          Probíhá údržba
+        </h1>
+        <p className="text-lg text-gray-700 leading-relaxed mb-4">
+          Aplikace je dočasně nedostupná z důvodu plánované údržby. Pracujeme na
+          obnovení provozu.
+        </p>
+        <p className="text-base text-gray-500">Děkujeme za pochopení.</p>
+      </div>
+    </main>
+  );
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,7 +3,9 @@
 import { useState } from 'react';
 import { GovButton, GovIcon } from '@gov-design-system-ce/react';
 import { useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
 
+import { isGatedPath } from '@/lib/site-status';
 import { ThemeSwitch } from '@/components/shared/ThemeSwitch';
 
 import { NavItems } from './NavItems';
@@ -11,9 +13,26 @@ import { NavItems } from './NavItems';
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const t = useTranslations('Header');
+  const pathname = usePathname();
 
   const handleToggleMenu = () => setIsMenuOpen((prev) => !prev);
   const handleCloseMenu = () => setIsMenuOpen(false);
+
+  if (isGatedPath(pathname)) {
+    return (
+      <header className="bg-white py-3 z-50">
+        <section className="mx-auto max-w-desktop px-5 flex items-center">
+          <a
+            href="./"
+            className="h-12 no-underline flex items-center text-blue-primary font-medium gap-2"
+          >
+            <GovIcon name="logo-lion" slot="icon-start" className="!size-10" />
+            {t('LogoTitle')}
+          </a>
+        </section>
+      </header>
+    );
+  }
 
   return (
     <>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { GovButton, GovIcon } from '@gov-design-system-ce/react';
-import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
-import { isGatedPath } from '@/lib/site-status';
 import { ThemeSwitch } from '@/components/shared/ThemeSwitch';
+import { isGatedPath } from '@/lib/site-status';
 
 import { NavItems } from './NavItems';
 

--- a/src/lib/site-status.ts
+++ b/src/lib/site-status.ts
@@ -1,0 +1,40 @@
+export type SiteStatus = 'live' | 'coming_soon' | 'maintenance';
+
+const VALID_STATUSES: readonly SiteStatus[] = [
+  'live',
+  'coming_soon',
+  'maintenance',
+] as const;
+
+export const BYPASS_COOKIE = 'dia-nahled';
+export const BYPASS_QUERY_PARAM = 'nahled';
+// Reserved literal that always clears the bypass cookie. The preview secret
+// must therefore never be set to this exact value.
+export const BYPASS_QUERY_VALUE_DISABLE = 'ne';
+
+/**
+ * Returns the preview bypass secret from the environment, or null if it is
+ * unset/blank. When null, the bypass mechanism is fully disabled — no value of
+ * `?nahled=...` will grant access and any existing cookie is ignored.
+ */
+export function getPreviewSecret(): string | null {
+  const raw = process.env.SITE_PREVIEW_SECRET;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === BYPASS_QUERY_VALUE_DISABLE) return null;
+  return trimmed;
+}
+
+export const COMING_SOON_PATH = '/coming-soon';
+export const MAINTENANCE_PATH = '/maintenance';
+
+export function parseSiteStatus(value: string | undefined): SiteStatus {
+  if (value && (VALID_STATUSES as readonly string[]).includes(value)) {
+    return value as SiteStatus;
+  }
+  return 'live';
+}
+
+export function isGatedPath(pathname: string): boolean {
+  return pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  BYPASS_COOKIE,
+  BYPASS_QUERY_PARAM,
+  BYPASS_QUERY_VALUE_DISABLE,
+  COMING_SOON_PATH,
+  getPreviewSecret,
+  MAINTENANCE_PATH,
+  parseSiteStatus,
+} from '@/lib/site-status';
+
+const BYPASS_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+export function middleware(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+  const bypassParam = searchParams.get(BYPASS_QUERY_PARAM);
+  const previewSecret = getPreviewSecret();
+
+  // ?nahled=ne → clear bypass cookie, redirect (force-test the gated state).
+  // Handled before the secret match so operators can always recover.
+  if (bypassParam === BYPASS_QUERY_VALUE_DISABLE) {
+    const cleanUrl = request.nextUrl.clone();
+    cleanUrl.searchParams.delete(BYPASS_QUERY_PARAM);
+    const response = NextResponse.redirect(cleanUrl);
+    response.cookies.delete(BYPASS_COOKIE);
+    return response;
+  }
+
+  // ?nahled=<secret> → set bypass cookie, redirect to clean URL.
+  // Only matches when SITE_PREVIEW_SECRET is configured and equal.
+  if (
+    previewSecret !== null &&
+    bypassParam !== null &&
+    bypassParam === previewSecret
+  ) {
+    const cleanUrl = request.nextUrl.clone();
+    cleanUrl.searchParams.delete(BYPASS_QUERY_PARAM);
+    const response = NextResponse.redirect(cleanUrl);
+    response.cookies.set({
+      name: BYPASS_COOKIE,
+      value: previewSecret,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+      path: '/',
+      maxAge: BYPASS_MAX_AGE_SECONDS,
+    });
+    return response;
+  }
+
+  const status = parseSiteStatus(process.env.SITE_STATUS);
+
+  if (status === 'live') {
+    return NextResponse.next();
+  }
+
+  // Allow already on gated pages so the rewrite target itself can render
+  if (pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH) {
+    return NextResponse.next();
+  }
+
+  // Bypass cookie holders see the live app. Cookie value must match the
+  // currently-configured secret — rotating SITE_PREVIEW_SECRET invalidates
+  // every previously issued bypass cookie.
+  if (
+    previewSecret !== null &&
+    request.cookies.get(BYPASS_COOKIE)?.value === previewSecret
+  ) {
+    return NextResponse.next();
+  }
+
+  const gatedPath =
+    status === 'maintenance' ? MAINTENANCE_PATH : COMING_SOON_PATH;
+  const url = request.nextUrl.clone();
+  url.pathname = gatedPath;
+  url.search = '';
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals, static assets, and health endpoint
+    // (the readiness probe must keep working when the site is gated).
+    '/((?!_next/static|_next/image|favicon.ico|assets/|api/health).*)',
+  ],
+};


### PR DESCRIPTION
## Summary

Adds a Coming Soon / Maintenance gate to the frontend. Driven by
environment variables so each environment can be flipped between
`live`, `coming_soon`, and `maintenance` without a rebuild.

## Behavior

`SITE_STATUS` is read by [src/middleware.ts](cci:7://file:///c:/Work/DIA/frontend/src/middleware.ts:0:0-0:0) on every request:

| Value | Effect |
|---|---|
| `live` | Normal request handling |
| `coming_soon` | All non-asset traffic rewritten to `/coming-soon` |
| `maintenance` | All non-asset traffic rewritten to `/maintenance` |

The matcher excludes `_next/static`, `_next/image`, `favicon.ico`,
`/assets/*`, and `/api/health` so static assets and the Container
App readiness probe keep working under any status.

### Bypass

`SITE_PREVIEW_SECRET` enables a query-string bypass:

| Request | Outcome |
|---|---|
| `?nahled=<secret>` | Set `dia-nahled=<secret>` cookie, 30-day Max-Age, redirect clean |
| `?nahled=ne` | Clear cookie |
| `?nahled=<anything else>` | Ignored |
| `SITE_PREVIEW_SECRET` unset | Bypass disabled — no cookie value is valid |

Cookie attributes: `HttpOnly`, `Secure`, `SameSite=Lax`, `Path=/`.
Cookie value equals the secret itself, so changing the env var
invalidates every previously issued cookie. The literal `"ne"` is
reserved as the cookie-clear value and is rejected by Terraform
validation upstream.

## Files

- [src/lib/site-status.ts](cci:7://file:///c:/Work/DIA/frontend/src/lib/site-status.ts:0:0-0:0) — [SiteStatus](cci:2://file:///c:/Work/DIA/tool-frontend/src/lib/site-status.ts:0:0-0:64) type, status parser, gated
  path constants, [getPreviewSecret()](cci:1://file:///c:/Work/DIA/frontend/src/lib/site-status.ts:14:0-25:1) reading
  `process.env.SITE_PREVIEW_SECRET`.
- [src/middleware.ts](cci:7://file:///c:/Work/DIA/frontend/src/middleware.ts:0:0-0:0) — request-time gate logic; `config.matcher`
  carve-outs for static assets and the health endpoint.
- `src/app/coming-soon/page.tsx`, `src/app/maintenance/page.tsx` —
  fully static, no backend calls.

## Notes

- Pair with the infrastructure PR that adds `SITE_STATUS` and
  `SITE_PREVIEW_SECRET` to the Container App env.
- Flip a live environment without redeploying:
  `az containerapp update -n <name> -g <rg> --set-env-vars SITE_STATUS=maintenance`
- Rotating the bypass secret in Terraform invalidates all existing
  bypass cookies on the next request.