### PR TITLE
Release v1.0.3 — coming-soon gate + middleware matcher fix

### DIFF
--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,4 +1,14 @@
 {
+  "ComingSoon": {
+    "Title": "Připravujeme",
+    "Description": "Validátor pro kontrolu a převod slovníků v rámci Informačního systému modelování dat právě připravujeme. O spuštění systému budeme informovat.",
+    "Acknowledgement": "Děkujeme za trpělivost."
+  },
+  "Maintenance": {
+    "Title": "Probíhá údržba",
+    "Description": "Aplikace je dočasně nedostupná z důvodu plánované údržby. Pracujeme na obnovení provozu.",
+    "Acknowledgement": "Děkujeme za pochopení."
+  },
   "Header": {
     "LogoTitle": "Informační systém pro modelování dat",
     "Nav": {

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { useTranslations } from 'next-intl';
 
 export const metadata: Metadata = {
   title: 'ISMD - Připravujeme',
@@ -7,18 +8,19 @@ export const metadata: Metadata = {
 };
 
 export default function ComingSoonPage() {
+
+const t = useTranslations('ComingSoon');
+
   return (
     <main className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16">
       <div className="max-w-2xl text-center">
         <h1 className="text-4xl font-medium text-blue-primary mb-6">
-          Připravujeme
+          {t('Title')}
         </h1>
         <p className="text-lg text-gray-700 leading-relaxed mb-4">
-          Validátor pro kontrolu a převod slovníků v rámci Informačního systému
-          pro modelování dat dokončujeme. Veřejně dostupný bude v nejbližší
-          době.
+          {t('Description')}
         </p>
-        <p className="text-base text-gray-500">Děkujeme za trpělivost.</p>
+        <p className="text-base text-gray-500">{t('Acknowledgement')}</p>
       </div>
     </main>
   );

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ISMD - Připravujeme',
+  description:
+    'Validátor pro kontrolu a převod slovníků v rámci Informačního systému pro modelování dat se připravuje k veřejnému spuštění.',
+};
+
+export default function ComingSoonPage() {
+  return (
+    <main className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16">
+      <div className="max-w-2xl text-center">
+        <h1 className="text-4xl font-medium text-blue-primary mb-6">
+          Připravujeme
+        </h1>
+        <p className="text-lg text-gray-700 leading-relaxed mb-4">
+          Validátor pro kontrolu a převod slovníků v rámci Informačního systému
+          pro modelování dat dokončujeme. Veřejně dostupný bude v nejbližší
+          době.
+        </p>
+        <p className="text-base text-gray-500">Děkujeme za trpělivost.</p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,12 +7,14 @@ import '../styles/globals.css';
 
 import { ReactNode } from 'react';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale } from 'next-intl/server';
 
 import type { EnvironmentVariables } from '@/components/contexts/Environment';
 import { Footer } from '@/components/footer/Footer';
 import { Header } from '@/components/header/Header';
+import { GATED_REQUEST_HEADER } from '@/lib/site-status';
 
 import Providers from './providers';
 
@@ -27,7 +29,7 @@ const loadEnvVariables = () => {
   return {
     NEXT_PUBLIC_BE_URL: process.env.NEXT_PUBLIC_BE_URL ?? undefined,
     environment: process.env.environment ?? 'development',
-  }
+  };
 };
 
 export default async function RootLayout({
@@ -36,11 +38,13 @@ export default async function RootLayout({
   children: ReactNode;
 }>) {
   const locale = await getLocale();
-  
+  const requestHeaders = await headers();
+  const isGated = requestHeaders.get(GATED_REQUEST_HEADER) === '1';
+
   const variables: EnvironmentVariables = {
     ...loadEnvVariables(),
-  }
-  
+  };
+
   return (
     <html lang={locale}>
       <NextIntlClientProvider>
@@ -51,10 +55,10 @@ export default async function RootLayout({
             }}
           />
           <Providers environmentVariables={variables}>
-            <Header />
+            <Header isGated={isGated} />
             {children}
           </Providers>
-          <Footer />
+          <Footer isGated={isGated} />
         </body>
       </NextIntlClientProvider>
     </html>

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ISMD - Probíhá údržba',
+  description: 'Aplikace je dočasně nedostupná z důvodu plánované údržby.',
+};
+
+export default function MaintenancePage() {
+  return (
+    <main className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16">
+      <div className="max-w-2xl text-center">
+        <h1 className="text-4xl font-medium text-blue-primary mb-6">
+          Probíhá údržba
+        </h1>
+        <p className="text-lg text-gray-700 leading-relaxed mb-4">
+          Aplikace je dočasně nedostupná z důvodu plánované údržby. Pracujeme na
+          obnovení provozu.
+        </p>
+        <p className="text-base text-gray-500">Děkujeme za pochopení.</p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { useTranslations } from 'next-intl';
 
 export const metadata: Metadata = {
   title: 'ISMD - Probíhá údržba',
@@ -6,17 +7,17 @@ export const metadata: Metadata = {
 };
 
 export default function MaintenancePage() {
+  const t = useTranslations('Maintenance');
   return (
     <main className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16">
       <div className="max-w-2xl text-center">
         <h1 className="text-4xl font-medium text-blue-primary mb-6">
-          Probíhá údržba
+          {t('Title')}
         </h1>
         <p className="text-lg text-gray-700 leading-relaxed mb-4">
-          Aplikace je dočasně nedostupná z důvodu plánované údržby. Pracujeme na
-          obnovení provozu.
+          {t('Description')}
         </p>
-        <p className="text-base text-gray-500">Děkujeme za pochopení.</p>
+        <p className="text-base text-gray-500">{t('Acknowledgement')}</p>
       </div>
     </main>
   );

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -7,8 +7,53 @@ import { scrollTop } from '@/lib/windowUtils';
 
 import { FooterColumn } from './FooterColumn';
 
-export const Footer = () => {
+interface Props {
+  isGated?: boolean;
+}
+
+export const Footer = ({ isGated = false }: Props) => {
   const t = useTranslations('Footer');
+
+  if (isGated) {
+    return (
+      <footer className="bg-blue py-12 text-white mt-auto">
+        <section className="max-w-desktop px-5 mx-auto space-y-12">
+          <div className="space-y-4">
+            <h5 className="font-medium text-xl">{t('ContactColumn.Title')}</h5>
+            <GovLink href={`mailto:${t('ContactColumn.Email')}`} size="s">
+              <GovIcon slot="icon-start" name="envelope" />
+              {t('ContactColumn.Email')}
+            </GovLink>
+          </div>
+          <div className="space-y-4">
+            <h6 className="text-lg font-medium">{t('ThanksSection.Title')}</h6>
+            <p className="text-sm">{t('ThanksSection.Text')}</p>
+            <ul className="flex gap-y-4 gap-x-6 flex-wrap">
+              <li>
+                <GovIcon name="logo-eu" />
+              </li>
+              <li>
+                <GovIcon name="logo-npo" />
+              </li>
+              <li>
+                <GovIcon name="logo-dia" />
+              </li>
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <hr className="!border-t-footer-separator" />
+            <div className="flex justify-between flex-wrap gap-y-4 gap-x-8 text-secondary text-xs">
+              <p>{t('FooterCopySection.Copyright')}</p>
+              <div className="flex gap-x-3">
+                <p>{t('FooterCopySection.Version')}</p>|
+                <p>{t('FooterCopySection.DesignSystem')}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </footer>
+    );
+  }
 
   return (
     <footer className="bg-blue py-12 text-white mt-auto">

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,7 +3,9 @@
 import { useState } from 'react';
 import { GovButton, GovIcon } from '@gov-design-system-ce/react';
 import { useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
 
+import { isGatedPath } from '@/lib/site-status';
 import { ThemeSwitch } from '@/components/shared/ThemeSwitch';
 
 import { NavItems } from './NavItems';
@@ -11,9 +13,26 @@ import { NavItems } from './NavItems';
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const t = useTranslations('Header');
+  const pathname = usePathname();
 
   const handleToggleMenu = () => setIsMenuOpen((prev) => !prev);
   const handleCloseMenu = () => setIsMenuOpen(false);
+
+  if (isGatedPath(pathname)) {
+    return (
+      <header className="bg-white py-3 z-50">
+        <section className="mx-auto max-w-desktop px-5 flex items-center">
+          <a
+            href="./"
+            className="h-12 no-underline flex items-center text-blue-primary font-medium gap-2"
+          >
+            <GovIcon name="logo-lion" slot="icon-start" className="!size-10" />
+            {t('LogoTitle')}
+          </a>
+        </section>
+      </header>
+    );
+  }
 
   return (
     <>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,7 +10,11 @@ import { isGatedPath } from '@/lib/site-status';
 
 import { NavItems } from './NavItems';
 
-export const Header = () => {
+interface Props {
+  isGated?: boolean;
+}
+
+export const Header = ({ isGated: isGatedProp }: Props = {}) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const t = useTranslations('Header');
   const pathname = usePathname();
@@ -18,7 +22,9 @@ export const Header = () => {
   const handleToggleMenu = () => setIsMenuOpen((prev) => !prev);
   const handleCloseMenu = () => setIsMenuOpen(false);
 
-  if (isGatedPath(pathname)) {
+  const isGated = isGatedProp ?? isGatedPath(pathname);
+
+  if (isGated) {
     return (
       <header className="bg-white py-3 z-50">
         <section className="mx-auto max-w-desktop px-5 flex items-center">

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { GovButton, GovIcon } from '@gov-design-system-ce/react';
-import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
-import { isGatedPath } from '@/lib/site-status';
 import { ThemeSwitch } from '@/components/shared/ThemeSwitch';
+import { isGatedPath } from '@/lib/site-status';
 
 import { NavItems } from './NavItems';
 

--- a/src/lib/site-status.ts
+++ b/src/lib/site-status.ts
@@ -1,0 +1,40 @@
+export type SiteStatus = 'live' | 'coming_soon' | 'maintenance';
+
+const VALID_STATUSES: readonly SiteStatus[] = [
+  'live',
+  'coming_soon',
+  'maintenance',
+] as const;
+
+export const BYPASS_COOKIE = 'dia-nahled';
+export const BYPASS_QUERY_PARAM = 'nahled';
+// Reserved literal that always clears the bypass cookie. The preview secret
+// must therefore never be set to this exact value.
+export const BYPASS_QUERY_VALUE_DISABLE = 'ne';
+
+/**
+ * Returns the preview bypass secret from the environment, or null if it is
+ * unset/blank. When null, the bypass mechanism is fully disabled — no value of
+ * `?nahled=...` will grant access and any existing cookie is ignored.
+ */
+export function getPreviewSecret(): string | null {
+  const raw = process.env.SITE_PREVIEW_SECRET;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === BYPASS_QUERY_VALUE_DISABLE) return null;
+  return trimmed;
+}
+
+export const COMING_SOON_PATH = '/coming-soon';
+export const MAINTENANCE_PATH = '/maintenance';
+
+export function parseSiteStatus(value: string | undefined): SiteStatus {
+  if (value && (VALID_STATUSES as readonly string[]).includes(value)) {
+    return value as SiteStatus;
+  }
+  return 'live';
+}
+
+export function isGatedPath(pathname: string): boolean {
+  return pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH;
+}

--- a/src/lib/site-status.ts
+++ b/src/lib/site-status.ts
@@ -38,3 +38,8 @@ export function parseSiteStatus(value: string | undefined): SiteStatus {
 export function isGatedPath(pathname: string): boolean {
   return pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH;
 }
+
+// Header set by middleware on gated requests so server components (layout)
+// can detect the gated state without depending on usePathname, which returns
+// the original (un-rewritten) pathname on the client after NextResponse.rewrite.
+export const GATED_REQUEST_HEADER = 'x-site-gated';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,12 +5,19 @@ import {
   BYPASS_QUERY_PARAM,
   BYPASS_QUERY_VALUE_DISABLE,
   COMING_SOON_PATH,
+  GATED_REQUEST_HEADER,
   getPreviewSecret,
   MAINTENANCE_PATH,
   parseSiteStatus,
 } from '@/lib/site-status';
 
 const BYPASS_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+function gatedRequestHeaders(request: NextRequest): Headers {
+  const headers = new Headers(request.headers);
+  headers.set(GATED_REQUEST_HEADER, '1');
+  return headers;
+}
 
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
@@ -55,9 +62,12 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Allow already on gated pages so the rewrite target itself can render
+  // Direct visit to a gated page — allow through but flag it so the layout
+  // renders the stripped header/footer regardless of the original pathname.
   if (pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH) {
-    return NextResponse.next();
+    return NextResponse.next({
+      request: { headers: gatedRequestHeaders(request) },
+    });
   }
 
   // Bypass cookie holders see the live app. Cookie value must match the
@@ -75,7 +85,9 @@ export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone();
   url.pathname = gatedPath;
   url.search = '';
-  return NextResponse.rewrite(url);
+  return NextResponse.rewrite(url, {
+    request: { headers: gatedRequestHeaders(request) },
+  });
 }
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  BYPASS_COOKIE,
+  BYPASS_QUERY_PARAM,
+  BYPASS_QUERY_VALUE_DISABLE,
+  COMING_SOON_PATH,
+  getPreviewSecret,
+  MAINTENANCE_PATH,
+  parseSiteStatus,
+} from '@/lib/site-status';
+
+const BYPASS_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+export function middleware(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+  const bypassParam = searchParams.get(BYPASS_QUERY_PARAM);
+  const previewSecret = getPreviewSecret();
+
+  // ?nahled=ne → clear bypass cookie, redirect (force-test the gated state).
+  // Handled before the secret match so operators can always recover.
+  if (bypassParam === BYPASS_QUERY_VALUE_DISABLE) {
+    const cleanUrl = request.nextUrl.clone();
+    cleanUrl.searchParams.delete(BYPASS_QUERY_PARAM);
+    const response = NextResponse.redirect(cleanUrl);
+    response.cookies.delete(BYPASS_COOKIE);
+    return response;
+  }
+
+  // ?nahled=<secret> → set bypass cookie, redirect to clean URL.
+  // Only matches when SITE_PREVIEW_SECRET is configured and equal.
+  if (
+    previewSecret !== null &&
+    bypassParam !== null &&
+    bypassParam === previewSecret
+  ) {
+    const cleanUrl = request.nextUrl.clone();
+    cleanUrl.searchParams.delete(BYPASS_QUERY_PARAM);
+    const response = NextResponse.redirect(cleanUrl);
+    response.cookies.set({
+      name: BYPASS_COOKIE,
+      value: previewSecret,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+      path: '/',
+      maxAge: BYPASS_MAX_AGE_SECONDS,
+    });
+    return response;
+  }
+
+  const status = parseSiteStatus(process.env.SITE_STATUS);
+
+  if (status === 'live') {
+    return NextResponse.next();
+  }
+
+  // Allow already on gated pages so the rewrite target itself can render
+  if (pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH) {
+    return NextResponse.next();
+  }
+
+  // Bypass cookie holders see the live app. Cookie value must match the
+  // currently-configured secret — rotating SITE_PREVIEW_SECRET invalidates
+  // every previously issued bypass cookie.
+  if (
+    previewSecret !== null &&
+    request.cookies.get(BYPASS_COOKIE)?.value === previewSecret
+  ) {
+    return NextResponse.next();
+  }
+
+  const gatedPath =
+    status === 'maintenance' ? MAINTENANCE_PATH : COMING_SOON_PATH;
+  const url = request.nextUrl.clone();
+  url.pathname = gatedPath;
+  url.search = '';
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals, static assets, and health endpoint
+    // (the readiness probe must keep working when the site is gated).
+    '/((?!_next/static|_next/image|favicon.ico|assets/|api/health).*)',
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -80,8 +80,13 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Skip Next.js internals, static assets, and health endpoint
+    // Match the bare basePath itself (e.g. /validujeme). Without this entry
+    // Next.js compiles a regex that requires a sub-path, so the gate would
+    // be invisible at the canonical URL — especially when an upstream proxy
+    // strips trailing slashes.
+    '/',
+    // Skip Next.js internals, static assets, health endpoints, and API routes
     // (the readiness probe must keep working when the site is gated).
-    '/((?!_next/static|_next/image|favicon.ico|assets/|api/health).*)',
+    '/((?!_next/static|_next/image|favicon.ico|assets/|api/health|api/auth).*)',
   ],
 };


### PR DESCRIPTION
# Release v1.0.3 — coming-soon gate + middleware matcher fix
## Summary

Cherry-picks the coming-soon site gate from `dev` onto `main` ahead of the TEST hostname go-live. Excludes the unrelated BFF refactor, swagger fix, docker-compose, and CI security work also pending on `dev` — those will ride a later release once PROD infra catches up.

## Changes

- **feat(middleware):** `SITE_STATUS`-driven gate (`live` / `coming_soon` / `maintenance`) with `SITE_PREVIEW_SECRET` bypass via `?nahled=<secret>` cookie; `?nahled=ne` clears it (cherry-pick `f2506e7`)
- **feat:** `/coming-soon` and `/maintenance` pages; header hides nav on gated paths via `isGatedPath` (cherry-pick `f2506e7`, `53cfc95`)
- **bugfix(middleware):** add `'/'` to the matcher so the gate fires on the bare basePath — upstream proxy strips trailing slashes, which made the gate invisible at canonical URLs (cherry-pick `6a50fea`, originally PR #98)

## Why cherry-pick instead of merging `dev → main`

`dev` also contains a lot of other changes, which we're not ready to release yet. This release ships only what TEST + PROD infra can both serve today to block access to the apps.

## Deployment behavior

1. Merge → tag `v1.0.3` auto-created
2. Docker image `v1.0.3` built
3. TEST auto-deploys (`SITE_STATUS=coming_soon` already set in infra)
4. PROD **not** auto-deployed — image stays pinned until PROD infra is ready
