### PR TITLE
ci: add Dependabot config targeting dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot — watches npm dependencies (package-lock.json committed).
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    # Scheduled version-update PRs open against dev for review before reaching main.
+    # NOTE: security updates always target the default branch and ignore this.
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    # One grouped PR per run instead of a separate PR per dependency.
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # Watches action versions pinned in .github/workflows/ (actions/checkout, etc.).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add .github/dependabot.yml for weekly grouped dependency updates and GitHub Actions version bumps. Version-update PRs open against dev for review before promotion to main; security updates still target main.